### PR TITLE
Fix a few style nits with Diesel usage

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4,13 +4,13 @@ use crate::{
 };
 use serenity::model::prelude::*;
 
-/// Send a reply to the channel the message was received on.  
+/// Send a reply to the channel the message was received on.
 pub(crate) fn send_reply(args: &Args, message: &str) -> Result<()> {
     args.msg.channel_id.say(&args.cx, message)?;
     Ok(())
 }
 
-/// Determine if a member sending a message has the `Role`.  
+/// Determine if a member sending a message has the `Role`.
 pub(crate) fn has_role(args: &Args, role: &RoleId) -> Result<bool> {
     Ok(args
         .msg
@@ -21,7 +21,7 @@ pub(crate) fn has_role(args: &Args, role: &RoleId) -> Result<bool> {
         .contains(role))
 }
 
-/// Return whether or not the user is a mod.  
+/// Return whether or not the user is a mod.
 pub(crate) fn is_mod(args: &Args) -> Result<bool> {
     use std::str::FromStr;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -27,17 +27,17 @@ impl MessageCache {
     ) -> Result<Option<(i32, String, String, String)>> {
         let conn = database_connection()?;
 
-        Ok(messages::table
+        messages::table
             .filter(messages::name.eq(name.into()))
-            .load::<(i32, String, String, String)>(&conn)?
-            .into_iter()
-            .nth(0))
+            .first::<(i32, String, String, String)>(&conn)
+            .optional()
+            .map_err(Into::into)
     }
 
     pub(crate) fn update_by_id(id: i32, message: MessageId, channel: ChannelId) -> Result<()> {
         let conn = database_connection()?;
 
-        diesel::update(messages::table.filter(messages::id.eq(id)))
+        diesel::update(messages::table.find(id))
             .set((
                 messages::message.eq(message.0.to_string()),
                 messages::channel.eq(channel.0.to_string()),
@@ -62,17 +62,17 @@ impl RoleIdCache {
     pub(crate) fn get_by_name(name: impl Into<String>) -> Result<Option<(i32, String, String)>> {
         let conn = database_connection()?;
 
-        Ok(roles::table
+        roles::table
             .filter(roles::name.eq(name.into()))
-            .load::<(i32, String, String)>(&conn)?
-            .into_iter()
-            .nth(0))
+            .first::<(i32, String, String)>(&conn)
+            .optional()
+            .map_err(Into::into)
     }
 
     pub(crate) fn update_by_id(id: i32, role: &str) -> Result<()> {
         let conn = database_connection()?;
 
-        diesel::update(roles::table.filter(roles::id.eq(id)))
+        diesel::update(roles::table.find(id))
             .set(roles::role.eq(role))
             .execute(&conn)?;
         Ok(())
@@ -94,17 +94,17 @@ impl UserIdCache {
     pub(crate) fn get_by_name(name: impl Into<String>) -> Result<Option<(i32, String, String)>> {
         let conn = database_connection()?;
 
-        Ok(users::table
+        users::table
             .filter(users::name.eq(name.into()))
-            .load::<(i32, String, String)>(&conn)?
-            .into_iter()
-            .nth(0))
+            .first::<(i32, String, String)>(&conn)
+            .optional()
+            .map_err(Into::into)
     }
 
     pub(crate) fn update_by_id(id: i32, name: &str, user_id: &str) -> Result<()> {
         let conn = database_connection()?;
 
-        diesel::update(users::table.filter(users::id.eq(id)))
+        diesel::update(users::table.find(id))
             .set((users::name.eq(name), users::user_id.eq(user_id)))
             .execute(&conn)?;
         Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,16 +5,10 @@ pub(crate) fn database_connection() -> Result<PgConnection> {
     Ok(PgConnection::establish(&std::env::var("DATABASE_URL")?)?)
 }
 
-pub(crate) fn run_migrations() -> Result<()> {
-    let migrations_dir = std::env::var("MIGRATIONS_DIR")
-        .map(|p| std::path::PathBuf::from(p))
-        .unwrap_or_else(|_| std::path::PathBuf::from("migrations"));
+embed_migrations!("migrations");
 
-    diesel_migrations::run_pending_migrations_in_directory(
-        &database_connection()?,
-        &migrations_dir,
-        &mut std::io::sink(),
-    )?;
+pub(crate) fn run_migrations() -> Result<()> {
+    embedded_migrations::run_with_output(&database_connection()?, &mut std::io::sink())?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate diesel;
+#[macro_use]
+extern crate diesel_migrations;
 
 mod api;
 mod cache;


### PR DESCRIPTION
These changes are mostly stylistic, but this code will now add `LIMIT 1`
to all the queries which are trying to get exactly one row. The changes
are:

- `table.filter(primary_key.eq(id))` => `table.find(id)`
- `.load()?.into_iter().nth(0)` => `.first().optional()`
  - Diesel treats "could not find a row" as an error by default,
    `.optional` just matches on `NotFound` and returns `None` instead
- Embed the migrations. If they're being run from the binary, there's no
  reason to require them on the file system to use it.

There were a few other structural issues that I didn't address, but
wanted to mention. All your `save_or_update` functions are super racy.
It looks like this uses PG, so this could use an
[upsert](http://docs.diesel.rs/diesel/pg/upsert/index.html) to avoid
that. At the very least, you should stick a `for_update` on those
selects (the ability to compose modifiers onto queries is why we usually
discourage writing functions that execute queries instead of returning
them). That would also require the call being in a transaction (which is
why we usually encourage passing a connection around explicitly)