### PR TITLE
Fix splitting codepoint for messages that start with an emoji

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -55,7 +55,7 @@ impl Commands {
     }
 
     pub(crate) fn execute<'m>(&'m self, cx: Context, msg: Message) {
-        if !msg.is_own(&cx) && &msg.content[..1] == PREFIX {
+        if !msg.is_own(&cx) && msg.content.starts_with(PREFIX) {
             let message = &msg.content.clone();
             self.state_machine.process(&message).map(|matched| {
                 info!("Executing command {}", message);


### PR DESCRIPTION
This PR is a fix for #20 when we check to see if a message starts with a `?` and the message starts with an emoji.  Currently this causes the the bot to panic since you cant take a slice from an emoji.  