### PR TITLE
Add the ?help command to the help menu

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -73,6 +73,7 @@ impl Commands {
     }
 
     pub(crate) fn menu(&mut self) -> Option<String> {
+        self.menu.as_mut().map(|menu| *menu += "?help\n");
         self.menu.take()
     }
 


### PR DESCRIPTION
This PR adds the `?help` command to the help menu.  