### PR TITLE
Add feature flags for tags crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+tags = []
+crates = []
+
 [dependencies]
 serenity = { version = "0.8.0", features = ["cache", "model"] }
 diesel = { version = "1.4.0", features = ["postgres", "r2d2"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN cargo build --release
 RUN rm -rf /tmp/source/src
 COPY src /tmp/source/src
 COPY migrations /tmp/source/migrations
-RUN find -name "*.rs" -exec touch {} \; && cargo build --release
+RUN find -name "*.rs" -exec touch {} \; && cargo build --release --features "tags crates"
 
 ##################
 #  Output image  #

--- a/src/api.rs
+++ b/src/api.rs
@@ -40,6 +40,7 @@ pub(crate) fn is_mod(args: &Args) -> Result<bool> {
     check_permission(args, role.map(|(_, role_id, _)| role_id))
 }
 
+#[cfg(any(feature = "crates", feature = "tags"))]
 pub(crate) fn is_wg_and_teams(args: &Args) -> Result<bool> {
     let role = roles::table
         .filter(roles::name.eq("wg_and_teams"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,6 @@ fn app() -> Result {
 
     #[cfg(feature = "crates")]
     {
-
         // crates.io
         cmds.add("?crate help", crates::help);
         cmds.add("?crate query...", crates::search);


### PR DESCRIPTION
This PR adds the `tags` and `crates` feature flags to the bot for conditionally managing capabilities.  

By default the `Dockerfile` is setup to build with the complete feature set.  