### PR TITLE
Temporary ban with automated unban

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serenity = { version = "0.8.0", features = ["cache", "model"] }
+serenity = { version = "0.8.0", features = ["model"] }
 diesel = { version = "1.4.0", features = ["postgres", "r2d2"] }
 diesel_migrations = { version = "1.4.0", features = ["postgres"] }
 reqwest = { version = "0.10", features = ["blocking", "json"] }

--- a/migrations/2020-08-25-224210_bans/down.sql
+++ b/migrations/2020-08-25-224210_bans/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS bans;

--- a/migrations/2020-08-25-224210_bans/up.sql
+++ b/migrations/2020-08-25-224210_bans/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE IF NOT EXISTS bans (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  guild_id TEXT NOT NULL,
+  unbanned BOOLEAN NOT NULL DEFAULT false,
+  start_time TIMESTAMP NOT NULL,
+  end_time TIMESTAMP NOT NULL
+);

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,8 @@
-use crate::{commands::{Args, Result}, db::DB, schema::roles, ban};
+use crate::{
+    commands::{Args, Result},
+    db::DB,
+    schema::roles,
+};
 use diesel::prelude::*;
 use serenity::{model::prelude::*, utils::parse_username};
 
@@ -87,36 +91,6 @@ pub(crate) fn kick(args: Args) -> Result<()> {
         if let Some(guild) = args.msg.guild(&args.cx) {
             info!("Kicking user from guild");
             guild.read().kick(&args.cx, UserId::from(user_id))?
-        }
-    }
-    Ok(())
-}
-
-/// Ban an user from the guild.  
-///
-/// Requires the ban members permission
-pub(crate) fn ban(args: Args) -> Result<()> {
-    if is_mod(&args)? {
-        let user_id = parse_username(
-            &args
-                .params
-                .get("user")
-                .ok_or("unable to retrieve user param")?,
-        )
-        .ok_or("unable to retrieve user id")?;
-
-        use std::str::FromStr;
-
-        let hours = u64::from_str(
-            args.params
-                .get("hours")
-                .ok_or("unable to retrieve hours param")?,
-        )?;
-
-        if let Some(guild) = args.msg.guild(&args.cx) {
-            info!("Banning user from guild");
-            guild.read().ban(args.cx, UserId::from(user_id), &"all")?;
-            ban::save_ban(format!("{}", user_id), format!("{}", guild.read().id), hours)?;
         }
     }
     Ok(())

--- a/src/ban.rs
+++ b/src/ban.rs
@@ -1,0 +1,69 @@
+use crate::{commands::Result, db::DB, schema::bans};
+use diesel::prelude::*;
+use serenity::{model::prelude::*, prelude::*};
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    thread::sleep,
+    time::{Duration, SystemTime},
+};
+
+static UNBAN_THREAD_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn save_ban(user_id: String, guild_id: String) -> Result<()> {
+    info!("Recording ban for user {}", &user_id);
+    let conn = DB.get()?;
+    diesel::insert_into(bans::table)
+        .values((
+            bans::user_id.eq(user_id),
+            bans::guild_id.eq(guild_id),
+            bans::start_time.eq(SystemTime::now()),
+            bans::end_time.eq(SystemTime::now()
+                .checked_add(Duration::new(1 * 60, 0))
+                .ok_or("out of range Duration for ban end_time")?),
+        ))
+        .execute(&conn)?;
+
+    Ok(())
+}
+
+pub(crate) fn save_unban(user_id: String, guild_id: String) -> Result<()> {
+    info!("Recording unban for user {}", &user_id);
+    let conn = DB.get()?;
+    diesel::update(bans::table)
+        .filter(
+            bans::user_id
+                .eq(user_id)
+                .and(bans::guild_id.eq(guild_id).and(bans::unbanned.eq(false))),
+        )
+        .set(bans::unbanned.eq(true))
+        .execute(&conn)?;
+    Ok(())
+}
+
+type SendSyncError = Box<dyn std::error::Error + Send + Sync>;
+
+pub(crate) fn start_unban_thread(cx: Context) {
+    use std::str::FromStr;
+    if !UNBAN_THREAD_INITIALIZED.load(Ordering::SeqCst) {
+        UNBAN_THREAD_INITIALIZED.store(true, Ordering::SeqCst);
+        std::thread::spawn(move || -> std::result::Result<(), SendSyncError> {
+            loop {
+                sleep(Duration::new(20, 0));
+                let conn = DB.get()?;
+                let to_unban = bans::table
+                    .filter(
+                        bans::unbanned
+                        .eq(false)
+                        .and(bans::end_time.le(SystemTime::now())),
+                    )
+                    .load::<(i32, String, String, bool, SystemTime, SystemTime)>(&conn)?;
+
+                for row in &to_unban {
+                    let guild_id = GuildId::from(u64::from_str(&row.2)?);
+                    info!("Unbanning user {}", &row.1);
+                    guild_id.unban(&cx, u64::from_str(&row.1)?)?;
+                }
+            }
+        });
+    }
+}

--- a/src/ban.rs
+++ b/src/ban.rs
@@ -1,6 +1,11 @@
-use crate::{api, commands::{Result, Args}, db::DB, schema::bans};
+use crate::{
+    api,
+    commands::{Args, Result},
+    db::DB,
+    schema::bans,
+};
 use diesel::prelude::*;
-use serenity::{prelude::*, model::prelude::*, utils::parse_username};
+use serenity::{model::prelude::*, prelude::*, utils::parse_username};
 use std::{
     sync::atomic::{AtomicBool, Ordering},
     thread::sleep,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -100,7 +100,6 @@ impl Commands {
 fn add_space(state_machine: &mut StateMachine, mut state: usize, i: usize) -> usize {
     if i > 0 {
         state = state_machine.add(state, CharacterSet::from_char(' '));
-        state_machine.add_next_state(state, state);
     }
     state
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -100,6 +100,7 @@ impl Commands {
 fn add_space(state_machine: &mut StateMachine, mut state: usize, i: usize) -> usize {
     if i > 0 {
         state = state_machine.add(state, CharacterSet::from_char(' '));
+        state_machine.add_next_state(state, state);
     }
     state
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate diesel_migrations;
 extern crate log;
 
 mod api;
+mod ban;
 mod commands;
 mod crates;
 mod db;
@@ -110,9 +111,6 @@ fn app() -> Result {
     // Kick
     cmds.add("?kick {user}", api::kick);
 
-    // Ban
-    cmds.add("?ban {user} {hours}", api::ban);
-
     // Post the welcome message to the welcome channel.
     cmds.add("?CoC {channel}", welcome::post_message);
 
@@ -153,6 +151,16 @@ impl RawEventHandler for Events {
                     println!("{}", e);
                 }
             }
+            Event::GuildBanAdd(ref ev) => {
+                if let Err(e) = ban::save_ban(format!("{}", ev.user.id), format!("{}", ev.guild_id)) {
+                    error!("{}", e);
+                }
+            }
+            Event::GuildBanRemove(ref ev) => {
+                if let Err(e) = ban::save_unban(format!("{}", ev.user.id), format!("{}", ev.guild_id)) {
+                    error!("{}", e);
+                }
+            }
             _ => (),
         }
     }
@@ -169,49 +177,6 @@ impl EventHandler for Messages {
 
     fn ready(&self, context: Context, ready: Ready) {
         info!("{} connected to discord", ready.user.name);
-        std::thread::spawn(
-            move || -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
-                use std::{
-                    thread::sleep,
-                    time::{Duration, SystemTime},
-                };
-                let cx = context;
-
-                use crate::schema::bans;
-                use std::str::FromStr;
-
-                let conn = DB.get()?;
-                loop {
-                    sleep(Duration::new(3600, 0));
-                    let _ = conn.build_transaction().read_write().run::<_, Box<
-                        dyn std::error::Error + Send + Sync,
-                    >, _>(
-                        || {
-                            let to_unban = bans::table
-                                .filter(
-                                    bans::unbanned
-                                        .eq(false)
-                                        .and(bans::end_time.le(SystemTime::now())),
-                                )
-                                .load::<(i32, String, String, bool, SystemTime, SystemTime)>(
-                                    &conn,
-                                )?;
-
-                            for row in &to_unban {
-                                let guild_id = GuildId::from(u64::from_str(&row.2)?);
-                                guild_id.unban(&cx, u64::from_str(&row.1)?)?;
-                                diesel::update(bans::table)
-                                    .filter(bans::id.eq(&row.0))
-                                    .set(bans::unbanned.eq(true))
-                                    .execute(&conn)?;
-                            }
-
-                            dbg!(to_unban);
-                            Ok(())
-                        },
-                    )?;
-                }
-            },
-        );
+        ban::start_unban_thread(context);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ impl RawEventHandler for Events {
         match event {
             Event::ReactionAdd(ref ev) => {
                 if let Err(e) = welcome::assign_talk_role(&cx, ev) {
-                    println!("{}", e);
+                    error!("{}", e);
                 }
             }
             Event::GuildBanRemove(ref ev) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,9 @@ fn app() -> Result {
     // Kick
     cmds.add("?kick {user}", api::kick);
 
+    // Ban
+    cmds.add("?ban {user} {hours}", api::ban);
+
     // Post the welcome message to the welcome channel.
     cmds.add("?CoC {channel}", welcome::post_message);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod db;
 mod schema;
 mod state_machine;
 mod tags;
+mod text;
 mod welcome;
 
 use crate::db::DB;
@@ -113,7 +114,7 @@ fn app() -> Result {
 
     // Ban
     cmds.add("?ban help", ban::help);
-    cmds.add("?ban {user} {hours}", ban::temp_ban);
+    cmds.add("?ban {user} {hours} reason...", ban::temp_ban);
 
     // Post the welcome message to the welcome channel.
     cmds.add("?CoC {channel}", welcome::post_message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,13 +154,10 @@ impl RawEventHandler for Events {
                     println!("{}", e);
                 }
             }
-            Event::GuildBanAdd(ref ev) => {
-                if let Err(e) = ban::save_ban(format!("{}", ev.user.id), format!("{}", ev.guild_id)) {
-                    error!("{}", e);
-                }
-            }
             Event::GuildBanRemove(ref ev) => {
-                if let Err(e) = ban::save_unban(format!("{}", ev.user.id), format!("{}", ev.guild_id)) {
+                if let Err(e) =
+                    ban::save_unban(format!("{}", ev.user.id), format!("{}", ev.guild_id))
+                {
                     error!("{}", e);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,8 @@ fn app() -> Result {
     cmds.add("?kick {user}", api::kick);
 
     // Ban
-    cmds.add("?ban {user} {hours}", api::ban);
+    cmds.add("?ban help", ban::help);
+    cmds.add("?ban {user} {hours}", ban::temp_ban);
 
     // Post the welcome message to the welcome channel.
     cmds.add("?CoC {channel}", welcome::post_message);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,15 @@
 table! {
+    bans (id) {
+        id -> Int4,
+        user_id -> Text,
+        guild_id -> Text,
+        unbanned -> Bool,
+        start_time -> Timestamp,
+        end_time -> Timestamp,
+    }
+}
+
+table! {
     messages (id) {
         id -> Int4,
         name -> Text,
@@ -31,4 +42,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(messages, roles, tags, users,);
+allow_tables_to_appear_in_same_query!(bans, messages, roles, tags, users,);

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,7 @@
+pub(crate) const WELCOME_BILLBOARD: &'static str = "By participating in this community, you agree to follow the Rust Code of Conduct, as linked below. Please click the :white_check_mark: below to acknowledge and gain access to the channels.
+
+  https://www.rust-lang.org/policies/code-of-conduct  ";
+
+pub(crate) fn ban_message(reason: &str, hours: u64) -> String {
+    format!("You have been banned from The Rust Programming Language discord server for {}. The ban will expire in {} hours. If you feel this action was taken unfairly, you can reach the Rust moderation team at rust-mods@rust-lang.org", reason, hours)
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -3,5 +3,5 @@ pub(crate) const WELCOME_BILLBOARD: &'static str = "By participating in this com
   https://www.rust-lang.org/policies/code-of-conduct  ";
 
 pub(crate) fn ban_message(reason: &str, hours: u64) -> String {
-    format!("You have been banned from The Rust Programming Language discord server for {}. The ban will expire in {} hours. If you feel this action was taken unfairly, you can reach the Rust moderation team at rust-mods@rust-lang.org", reason, hours)
+    format!("You have been banned from The Rust Programming Language discord server for {}. The ban will expire in {} hours. If you feel this action was taken unfairly, you can reach the Rust moderation team at discord-mods@rust-lang.org", reason, hours)
 }

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -3,6 +3,7 @@ use crate::{
     commands::Args,
     db::DB,
     schema::{messages, roles, users},
+    text::WELCOME_BILLBOARD,
     Result,
 };
 use diesel::prelude::*;
@@ -11,10 +12,6 @@ use serenity::{model::prelude::*, prelude::*};
 /// Write the welcome message to the welcome channel.  
 pub(crate) fn post_message(args: Args) -> Result {
     use std::str::FromStr;
-
-    const WELCOME_BILLBOARD: &'static str = "By participating in this community, you agree to follow the Rust Code of Conduct, as linked below. Please click the :white_check_mark: below to acknowledge and gain access to the channels.
-
-  https://www.rust-lang.org/policies/code-of-conduct  ";
 
     if api::is_mod(&args)? {
         let channel_name = &args


### PR DESCRIPTION
This PR introduces the `?ban {user} {hours} reason...` command.  This command temporarily bans a user for hours specified and sends the banned user a dm with the following content: 

```
You have been banned from The Rust Programming Language discord server for {reason}. The ban will expire in {hours} hours. If you feel this action was taken unfairly, you can reach the Rust moderation team at discord-mods@rust-lang.org
```

Additionally, this PR introduces a `?ban help` command that explains, with examples, how to use the ban command.

#44 