### PR TITLE
Add support for multi-spaced commands

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -100,6 +100,7 @@ impl Commands {
 fn add_space(state_machine: &mut StateMachine, mut state: usize, i: usize) -> usize {
     if i > 0 {
         state = state_machine.add(state, CharacterSet::from_char(' '));
+        state_machine.add_next_state(state, state);
     }
     state
 }


### PR DESCRIPTION
This PR adds support for variable width spaces in commands submitted to the bot.  For example 
```sh
?tag foo
```
and
```sh
?tag       foo
```
are the same.  I want this so that when I autocomplete a name into a command or paste an id, I dont have to worry about an extra space causing the command to not be recognized.  