### PR TITLE
Code commands

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -43,10 +43,10 @@ impl Commands {
             .filter(|segment| segment.len() > 0)
             .enumerate()
             .for_each(|(i, segment)| {
-                if segment.starts_with("```\n") && segment.ends_with("\n```") {
+                if segment.starts_with("```\n") && segment.ends_with("```") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_code_segment_multi_line(&mut self.state_machine, state);
-                    param_names.push(&segment[4..segment.len() - 4]);
+                    param_names.push(&segment[4..segment.len() - 3]);
                 } else if segment.starts_with("```") && segment.ends_with("```") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_code_segment_single_line_long(&mut self.state_machine, state);
@@ -159,7 +159,7 @@ fn add_code_segment_multi_line(state_machine: &mut StateMachine, mut state: usiz
     state_machine.add_next_state(state, state);
     state_machine.start_parse(state);
     state_machine.end_parse(state);
-    state = state_machine.add(state, CharacterSet::from_char('\n'));
+
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,32 +47,26 @@ impl Commands {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_quoted_dynamic_segment(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
-
                 } else if segment.starts_with("```rust\n") && segment.ends_with("\n```") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_code_segment1(&mut self.state_machine, state);
                     param_names.push(&segment[8..segment.len() - 4]);
-
                 } else if segment.starts_with("```") && segment.ends_with("```") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_code_segment2(&mut self.state_machine, state);
                     param_names.push(&segment[3..segment.len() - 3]);
-
                 } else if segment.starts_with("`") && segment.ends_with("`") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_code_segment3(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
-
                 } else if segment.starts_with("{") && segment.ends_with("}") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_dynamic_segment(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
-
                 } else if segment.ends_with("...") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_remaining_segment(&mut self.state_machine, state);
                     param_names.push(&segment[..segment.len() - 3]);
-
                 } else {
                     state = add_space(&mut self.state_machine, state, i);
                     segment.chars().for_each(|ch| {
@@ -179,7 +173,6 @@ fn add_code_segment1(state_machine: &mut StateMachine, mut state: usize) -> usiz
 
     state
 }
-
 
 #[inline]
 fn add_code_segment2(state_machine: &mut StateMachine, mut state: usize) -> usize {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,6 +47,10 @@ impl Commands {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_quoted_dynamic_segment(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
+                } else if segment.starts_with("```") && segment.ends_with("```") {
+                    state = add_space(&mut self.state_machine, state, i);
+                    state = add_triple_tick_code_segment(&mut self.state_machine, state);
+                    param_names.push(&segment[3..segment.len() - 3]);
                 } else if segment.starts_with("{") && segment.ends_with("}") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_dynamic_segment(&mut self.state_machine, state);
@@ -136,6 +140,22 @@ fn add_quoted_dynamic_segment(state_machine: &mut StateMachine, mut state: usize
     state_machine.start_parse(state);
     state_machine.end_parse(state);
     state = state_machine.add(state, CharacterSet::from_char('"'));
+
+    state
+}
+
+#[inline]
+fn add_triple_tick_code_segment(state_machine: &mut StateMachine, mut state: usize) -> usize {
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::any());
+    state_machine.add_next_state(state, state);
+    state_machine.start_parse(state);
+    state_machine.end_parse(state);
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
 
     state
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,18 +47,32 @@ impl Commands {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_quoted_dynamic_segment(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
+
+                } else if segment.starts_with("```rust\n") && segment.ends_with("\n```") {
+                    state = add_space(&mut self.state_machine, state, i);
+                    state = add_code_segment1(&mut self.state_machine, state);
+                    param_names.push(&segment[8..segment.len() - 4]);
+
                 } else if segment.starts_with("```") && segment.ends_with("```") {
                     state = add_space(&mut self.state_machine, state, i);
-                    state = add_triple_tick_code_segment(&mut self.state_machine, state);
+                    state = add_code_segment2(&mut self.state_machine, state);
                     param_names.push(&segment[3..segment.len() - 3]);
+
+                } else if segment.starts_with("`") && segment.ends_with("`") {
+                    state = add_space(&mut self.state_machine, state, i);
+                    state = add_code_segment3(&mut self.state_machine, state);
+                    param_names.push(&segment[1..segment.len() - 1]);
+
                 } else if segment.starts_with("{") && segment.ends_with("}") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_dynamic_segment(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
+
                 } else if segment.ends_with("...") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_remaining_segment(&mut self.state_machine, state);
                     param_names.push(&segment[..segment.len() - 3]);
+
                 } else {
                     state = add_space(&mut self.state_machine, state, i);
                     segment.chars().for_each(|ch| {
@@ -145,7 +159,30 @@ fn add_quoted_dynamic_segment(state_machine: &mut StateMachine, mut state: usize
 }
 
 #[inline]
-fn add_triple_tick_code_segment(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_code_segment1(state_machine: &mut StateMachine, mut state: usize) -> usize {
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('r'));
+    state = state_machine.add(state, CharacterSet::from_char('u'));
+    state = state_machine.add(state, CharacterSet::from_char('s'));
+    state = state_machine.add(state, CharacterSet::from_char('t'));
+    state = state_machine.add(state, CharacterSet::from_char('\n'));
+    state = state_machine.add(state, CharacterSet::any());
+    state_machine.add_next_state(state, state);
+    state_machine.start_parse(state);
+    state_machine.end_parse(state);
+    state = state_machine.add(state, CharacterSet::from_char('\n'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+
+    state
+}
+
+
+#[inline]
+fn add_code_segment2(state_machine: &mut StateMachine, mut state: usize) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
@@ -155,6 +192,18 @@ fn add_triple_tick_code_segment(state_machine: &mut StateMachine, mut state: usi
     state_machine.end_parse(state);
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+
+    state
+}
+
+#[inline]
+fn add_code_segment3(state_machine: &mut StateMachine, mut state: usize) -> usize {
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::any());
+    state_machine.add_next_state(state, state);
+    state_machine.start_parse(state);
+    state_machine.end_parse(state);
     state = state_machine.add(state, CharacterSet::from_char('`'));
 
     state

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -51,13 +51,17 @@ impl Commands {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_code_segment1(&mut self.state_machine, state);
                     param_names.push(&segment[8..segment.len() - 4]);
-                } else if segment.starts_with("```") && segment.ends_with("```") {
+                } else if segment.starts_with("```\n") && segment.ends_with("\n```") {
                     state = add_space(&mut self.state_machine, state, i);
                     state = add_code_segment2(&mut self.state_machine, state);
+                    param_names.push(&segment[4..segment.len() - 4]);
+                } else if segment.starts_with("```") && segment.ends_with("```") {
+                    state = add_space(&mut self.state_machine, state, i);
+                    state = add_code_segment3(&mut self.state_machine, state);
                     param_names.push(&segment[3..segment.len() - 3]);
                 } else if segment.starts_with("`") && segment.ends_with("`") {
                     state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment3(&mut self.state_machine, state);
+                    state = add_code_segment4(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
                 } else if segment.starts_with("{") && segment.ends_with("}") {
                     state = add_space(&mut self.state_machine, state, i);
@@ -179,6 +183,24 @@ fn add_code_segment2(state_machine: &mut StateMachine, mut state: usize) -> usiz
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('\n'));
+    state = state_machine.add(state, CharacterSet::any());
+    state_machine.add_next_state(state, state);
+    state_machine.start_parse(state);
+    state_machine.end_parse(state);
+    state = state_machine.add(state, CharacterSet::from_char('\n'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+
+    state
+}
+
+#[inline]
+fn add_code_segment3(state_machine: &mut StateMachine, mut state: usize) -> usize {
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);
     state_machine.start_parse(state);
@@ -191,7 +213,7 @@ fn add_code_segment2(state_machine: &mut StateMachine, mut state: usize) -> usiz
 }
 
 #[inline]
-fn add_code_segment3(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_code_segment4(state_machine: &mut StateMachine, mut state: usize) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -43,25 +43,17 @@ impl Commands {
             .filter(|segment| segment.len() > 0)
             .enumerate()
             .for_each(|(i, segment)| {
-                if segment.starts_with("[") && segment.ends_with("]") {
+                if segment.starts_with("```\n") && segment.ends_with("\n```") {
                     state = add_space(&mut self.state_machine, state, i);
-                    state = add_quoted_dynamic_segment(&mut self.state_machine, state);
-                    param_names.push(&segment[1..segment.len() - 1]);
-                } else if segment.starts_with("```rust\n") && segment.ends_with("\n```") {
-                    state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment1(&mut self.state_machine, state);
-                    param_names.push(&segment[8..segment.len() - 4]);
-                } else if segment.starts_with("```\n") && segment.ends_with("\n```") {
-                    state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment2(&mut self.state_machine, state);
+                    state = add_code_segment_multi_line(&mut self.state_machine, state);
                     param_names.push(&segment[4..segment.len() - 4]);
                 } else if segment.starts_with("```") && segment.ends_with("```") {
                     state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment3(&mut self.state_machine, state);
+                    state = add_code_segment_single_line_long(&mut self.state_machine, state);
                     param_names.push(&segment[3..segment.len() - 3]);
                 } else if segment.starts_with("`") && segment.ends_with("`") {
                     state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment4(&mut self.state_machine, state);
+                    state = add_code_segment_single_line_short(&mut self.state_machine, state);
                     param_names.push(&segment[1..segment.len() - 1]);
                 } else if segment.starts_with("{") && segment.ends_with("}") {
                     state = add_space(&mut self.state_machine, state, i);
@@ -145,45 +137,24 @@ fn add_remaining_segment(state_machine: &mut StateMachine, mut state: usize) -> 
 }
 
 #[inline]
-fn add_quoted_dynamic_segment(state_machine: &mut StateMachine, mut state: usize) -> usize {
-    state = state_machine.add(state, CharacterSet::from_char('"'));
-    state = state_machine.add(state, CharacterSet::any());
+fn add_code_segment_multi_line(state_machine: &mut StateMachine, mut state: usize) -> usize {
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+    state = state_machine.add(state, CharacterSet::from_char('`'));
+
+    let lambda = state;
+
+    let mut char_set = CharacterSet::any();
+    char_set.remove('`');
+    char_set.remove(' ');
+    char_set.remove('\n');
+    state = state_machine.add(state, char_set);
     state_machine.add_next_state(state, state);
-    state_machine.start_parse(state);
-    state_machine.end_parse(state);
-    state = state_machine.add(state, CharacterSet::from_char('"'));
 
-    state
-}
-
-#[inline]
-fn add_code_segment1(state_machine: &mut StateMachine, mut state: usize) -> usize {
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('r'));
-    state = state_machine.add(state, CharacterSet::from_char('u'));
-    state = state_machine.add(state, CharacterSet::from_char('s'));
-    state = state_machine.add(state, CharacterSet::from_char('t'));
     state = state_machine.add(state, CharacterSet::from_char('\n'));
-    state = state_machine.add(state, CharacterSet::any());
-    state_machine.add_next_state(state, state);
-    state_machine.start_parse(state);
-    state_machine.end_parse(state);
-    state = state_machine.add(state, CharacterSet::from_char('\n'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
 
-    state
-}
+    state_machine.add_next_state(lambda, state);
 
-#[inline]
-fn add_code_segment2(state_machine: &mut StateMachine, mut state: usize) -> usize {
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('\n'));
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);
     state_machine.start_parse(state);
@@ -197,7 +168,7 @@ fn add_code_segment2(state_machine: &mut StateMachine, mut state: usize) -> usiz
 }
 
 #[inline]
-fn add_code_segment3(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_code_segment_single_line_long(state_machine: &mut StateMachine, mut state: usize) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
@@ -213,7 +184,7 @@ fn add_code_segment3(state_machine: &mut StateMachine, mut state: usize) -> usiz
 }
 
 #[inline]
-fn add_code_segment4(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_code_segment_single_line_short(state_machine: &mut StateMachine, mut state: usize) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -107,7 +107,10 @@ impl Commands {
 #[inline]
 fn add_space(state_machine: &mut StateMachine, mut state: usize, i: usize) -> usize {
     if i > 0 {
-        state = state_machine.add(state, CharacterSet::from_char(' '));
+        let mut char_set = CharacterSet::from_char(' ');
+        char_set.insert('\n');
+
+        state = state_machine.add(state, char_set);
         state_machine.add_next_state(state, state);
     }
     state

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,21 +86,6 @@ fn app() -> Result {
 
     let mut cmds = Commands::new();
 
-    cmds.add("?play ```rust\ncode\n```", |args: Args| {
-        let input = dbg!(args.params.get("code").unwrap());
-        Ok(())
-    });
-
-    cmds.add("?play ```code```", |args: Args| {
-        let input = dbg!(args.params.get("code").unwrap());
-        Ok(())
-    });
-
-    cmds.add("?play `code`", |args: Args| {
-        let input = dbg!(args.params.get("code").unwrap());
-        Ok(())
-    });
-
     if config.tags {
         // Tags
         cmds.add("?tags delete {key}", tags::delete);

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,15 +86,18 @@ fn app() -> Result {
 
     let mut cmds = Commands::new();
 
-    cmds.add("?play ```code```", |args: Args| {
-        let input = args.params.get("code").unwrap();
-        let code = if input.starts_with("rust\n") && input.ends_with("\n") {
-            &input[5..input.len()-1]
-        } else {
-            &input
-        };
+    cmds.add("?play ```rust\ncode\n```", |args: Args| {
+        let input = dbg!(args.params.get("code").unwrap());
+        Ok(())
+    });
 
-        dbg!(code);
+    cmds.add("?play ```code```", |args: Args| {
+        let input = dbg!(args.params.get("code").unwrap());
+        Ok(())
+    });
+
+    cmds.add("?play `code`", |args: Args| {
+        let input = dbg!(args.params.get("code").unwrap());
         Ok(())
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,18 @@ fn app() -> Result {
 
     let mut cmds = Commands::new();
 
+    cmds.add("?play ```code```", |args: Args| {
+        let input = args.params.get("code").unwrap();
+        let code = if input.starts_with("rust\n") && input.ends_with("\n") {
+            &input[5..input.len()-1]
+        } else {
+            &input
+        };
+
+        dbg!(code);
+        Ok(())
+    });
+
     if config.tags {
         // Tags
         cmds.add("?tags delete {key}", tags::delete);


### PR DESCRIPTION
This PR adds support for the all the types of code blocks that exist on discord.  

- [x] triple back ticks ` ```code``` `
- [x] single back ticks ``` `code` ```
- [x] triple back ticks with an **optional** language specifier, note newline is non-optional ` ```\ncode``` `


----
### Usage Example
```rust
    cmds.add("?play ```\ncode```", |args: Args| {
        dbg!(args.params);
        Ok(())
    });
    cmds.add("?play ```code```", |args: Args| {
        dbg!(args.params);
        Ok(())
    });
    cmds.add("?play `code`", |args: Args| {
        dbg!(args.params);
        Ok(())
    });
```
In all examples above, `code` is extracted as a param in the command handler.  