### PR TITLE
Add support for optional arguments

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,11 +1,11 @@
 use crate::state_machine::{CharacterSet, StateMachine};
 use reqwest::blocking::Client as HttpClient;
 use serenity::{model::channel::Message, prelude::Context};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 const PREFIX: &'static str = "?";
 pub(crate) type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-pub(crate) type CmdPtr = Box<dyn for<'m> Fn(Args<'m>) -> Result<()> + Send + Sync>;
+pub(crate) type CmdPtr = Arc<dyn for<'m> Fn(Args<'m>) -> Result<()> + Send + Sync>;
 
 pub struct Args<'m> {
     pub http: &'m HttpClient,
@@ -35,45 +35,71 @@ impl Commands {
         handler: impl Fn(Args) -> Result<()> + Send + Sync + 'static,
     ) {
         info!("Adding command {}", &command);
-        let mut param_names = Vec::new();
         let mut state = 0;
+
+        let mut opt_lambda_state: Option<usize> = None;
+        let mut opt_final_states = vec![];
 
         command
             .split(' ')
             .filter(|segment| segment.len() > 0)
             .enumerate()
             .for_each(|(i, segment)| {
-                if segment.starts_with("```\n") && segment.ends_with("```") {
-                    state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment_multi_line(&mut self.state_machine, state);
-                    param_names.push(&segment[4..segment.len() - 3]);
-                } else if segment.starts_with("```") && segment.ends_with("```") {
-                    state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment_single_line_long(&mut self.state_machine, state);
-                    param_names.push(&segment[3..segment.len() - 3]);
-                } else if segment.starts_with("`") && segment.ends_with("`") {
-                    state = add_space(&mut self.state_machine, state, i);
-                    state = add_code_segment_single_line_short(&mut self.state_machine, state);
-                    param_names.push(&segment[1..segment.len() - 1]);
-                } else if segment.starts_with("{") && segment.ends_with("}") {
-                    state = add_space(&mut self.state_machine, state, i);
-                    state = add_dynamic_segment(&mut self.state_machine, state);
-                    param_names.push(&segment[1..segment.len() - 1]);
-                } else if segment.ends_with("...") {
-                    state = add_space(&mut self.state_machine, state, i);
-                    state = add_remaining_segment(&mut self.state_machine, state);
-                    param_names.push(&segment[..segment.len() - 3]);
+                if let Some(name) = key_value_pair(segment) {
+                    if let Some(lambda) = opt_lambda_state {
+                        state = add_key_value(&name, &mut self.state_machine, lambda);
+                        self.state_machine.add_next_state(state, lambda);
+                        opt_final_states.push(state);
+                    } else {
+                        opt_final_states.push(state);
+                        state = add_space(&mut self.state_machine, state, i);
+                        opt_lambda_state = Some(state);
+                        state = add_key_value(&name, &mut self.state_machine, state);
+                        self.state_machine
+                            .add_next_state(state, opt_lambda_state.unwrap());
+                        opt_final_states.push(state);
+                    }
                 } else {
+                    opt_lambda_state = None;
+                    opt_final_states.truncate(0);
                     state = add_space(&mut self.state_machine, state, i);
-                    segment.chars().for_each(|ch| {
-                        state = self.state_machine.add(state, CharacterSet::from_char(ch))
-                    });
+
+                    if segment.starts_with("```\n") && segment.ends_with("```") {
+                        let name = &segment[4..segment.len() - 3];
+                        state = add_code_segment_multi_line(name, &mut self.state_machine, state);
+                    } else if segment.starts_with("```") && segment.ends_with("```") {
+                        let name = &segment[3..segment.len() - 3];
+                        state = add_code_segment_single_line_long(name, &mut self.state_machine, state);
+                    } else if segment.starts_with("`") && segment.ends_with("`") {
+                        let name = &segment[1..segment.len() - 1];
+                        state =
+                            add_code_segment_single_line_short(name, &mut self.state_machine, state);
+                    } else if segment.starts_with("{") && segment.ends_with("}") {
+                        let name = &segment[1..segment.len() - 1];
+                        state = add_dynamic_segment(name, &mut self.state_machine, state);
+                    } else if segment.ends_with("...") {
+                        let name = &segment[..segment.len() - 3];
+                        state = add_remaining_segment(name, &mut self.state_machine, state);
+                    } else {
+                        segment.chars().for_each(|ch| {
+                            state = self.state_machine.add(state, CharacterSet::from_char(ch))
+                        });
+                    }
                 }
             });
 
-        self.state_machine.set_final_state(state);
-        self.state_machine.set_handler(state, Box::new(handler));
-        self.state_machine.set_param_names(state, param_names);
+        let handler = Arc::new(handler);
+
+        if opt_lambda_state.is_some() {
+            opt_final_states.iter().for_each(|state| {
+                self.state_machine.set_final_state(*state);
+                self.state_machine.set_handler(*state, handler.clone());
+            });
+        } else {
+            self.state_machine.set_final_state(state);
+            self.state_machine.set_handler(state, handler.clone());
+        }
+
         self.menu.as_mut().map(|menu| {
             *menu += command;
             *menu += "\n"
@@ -104,7 +130,20 @@ impl Commands {
     }
 }
 
-#[inline]
+fn key_value_pair(s: &'static str) -> Option<&'static str> {
+    s.match_indices("={}")
+        .nth(0)
+        .map(|pair| {
+            let name = &s[0..pair.0];
+            if name.len() > 0 {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .flatten()
+}
+
 fn add_space(state_machine: &mut StateMachine, mut state: usize, i: usize) -> usize {
     if i > 0 {
         let mut char_set = CharacterSet::from_char(' ');
@@ -116,31 +155,40 @@ fn add_space(state_machine: &mut StateMachine, mut state: usize, i: usize) -> us
     state
 }
 
-#[inline]
-fn add_dynamic_segment(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_dynamic_segment(
+    name: &'static str,
+    state_machine: &mut StateMachine,
+    mut state: usize,
+) -> usize {
     let mut char_set = CharacterSet::any();
     char_set.remove(' ');
     state = state_machine.add(state, char_set);
     state_machine.add_next_state(state, state);
-    state_machine.start_parse(state);
+    state_machine.start_parse(state, name);
     state_machine.end_parse(state);
 
     state
 }
 
-#[inline]
-fn add_remaining_segment(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_remaining_segment(
+    name: &'static str,
+    state_machine: &mut StateMachine,
+    mut state: usize,
+) -> usize {
     let char_set = CharacterSet::any();
     state = state_machine.add(state, char_set);
     state_machine.add_next_state(state, state);
-    state_machine.start_parse(state);
+    state_machine.start_parse(state, name);
     state_machine.end_parse(state);
 
     state
 }
 
-#[inline]
-fn add_code_segment_multi_line(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_code_segment_multi_line(
+    name: &'static str,
+    state_machine: &mut StateMachine,
+    mut state: usize,
+) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
@@ -160,7 +208,7 @@ fn add_code_segment_multi_line(state_machine: &mut StateMachine, mut state: usiz
 
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);
-    state_machine.start_parse(state);
+    state_machine.start_parse(state, name);
     state_machine.end_parse(state);
 
     state = state_machine.add(state, CharacterSet::from_char('`'));
@@ -170,14 +218,17 @@ fn add_code_segment_multi_line(state_machine: &mut StateMachine, mut state: usiz
     state
 }
 
-#[inline]
-fn add_code_segment_single_line_long(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_code_segment_single_line_long(
+    name: &'static str,
+    state_machine: &mut StateMachine,
+    mut state: usize,
+) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);
-    state_machine.start_parse(state);
+    state_machine.start_parse(state, name);
     state_machine.end_parse(state);
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::from_char('`'));
@@ -186,14 +237,34 @@ fn add_code_segment_single_line_long(state_machine: &mut StateMachine, mut state
     state
 }
 
-#[inline]
-fn add_code_segment_single_line_short(state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_code_segment_single_line_short(
+    name: &'static str,
+    state_machine: &mut StateMachine,
+    mut state: usize,
+) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);
-    state_machine.start_parse(state);
+    state_machine.start_parse(state, name);
     state_machine.end_parse(state);
     state = state_machine.add(state, CharacterSet::from_char('`'));
+
+    state
+}
+
+fn add_key_value(name: &'static str, state_machine: &mut StateMachine, mut state: usize) -> usize {
+    name.chars().for_each(|c| {
+        state = state_machine.add(state, CharacterSet::from_char(c));
+    });
+    state = state_machine.add(state, CharacterSet::from_char('='));
+
+    let mut char_set = CharacterSet::any();
+    char_set.remove(' ');
+    char_set.remove('\n');
+    state = state_machine.add(state, char_set);
+    state_machine.add_next_state(state, state);
+    state_machine.start_parse(state, name);
+    state_machine.end_parse(state);
 
     state
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -69,11 +69,12 @@ impl Commands {
                         state = add_code_segment_multi_line(name, &mut self.state_machine, state);
                     } else if segment.starts_with("```") && segment.ends_with("```") {
                         let name = &segment[3..segment.len() - 3];
-                        state = add_code_segment_single_line_long(name, &mut self.state_machine, state);
+                        state =
+                            add_code_segment_single_line(name, &mut self.state_machine, state, 3);
                     } else if segment.starts_with("`") && segment.ends_with("`") {
                         let name = &segment[1..segment.len() - 1];
                         state =
-                            add_code_segment_single_line_short(name, &mut self.state_machine, state);
+                            add_code_segment_single_line(name, &mut self.state_machine, state, 1);
                     } else if segment.starts_with("{") && segment.ends_with("}") {
                         let name = &segment[1..segment.len() - 1];
                         state = add_dynamic_segment(name, &mut self.state_machine, state);
@@ -218,36 +219,22 @@ fn add_code_segment_multi_line(
     state
 }
 
-fn add_code_segment_single_line_long(
+fn add_code_segment_single_line(
     name: &'static str,
     state_machine: &mut StateMachine,
     mut state: usize,
+    n_backticks: usize,
 ) -> usize {
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
+    (0..n_backticks).for_each(|_| {
+        state = state_machine.add(state, CharacterSet::from_char('`'));
+    });
     state = state_machine.add(state, CharacterSet::any());
     state_machine.add_next_state(state, state);
     state_machine.start_parse(state, name);
     state_machine.end_parse(state);
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-
-    state
-}
-
-fn add_code_segment_single_line_short(
-    name: &'static str,
-    state_machine: &mut StateMachine,
-    mut state: usize,
-) -> usize {
-    state = state_machine.add(state, CharacterSet::from_char('`'));
-    state = state_machine.add(state, CharacterSet::any());
-    state_machine.add_next_state(state, state);
-    state_machine.start_parse(state, name);
-    state_machine.end_parse(state);
-    state = state_machine.add(state, CharacterSet::from_char('`'));
+    (0..n_backticks).for_each(|_| {
+        state = state_machine.add(state, CharacterSet::from_char('`'));
+    });
 
     state
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -37,7 +37,7 @@ impl Commands {
         info!("Adding command {}", &command);
         let mut state = 0;
 
-        let mut opt_lambda_state: Option<usize> = None;
+        let mut opt_lambda_state = None;
         let mut opt_final_states = vec![];
 
         command
@@ -47,14 +47,14 @@ impl Commands {
             .for_each(|(i, segment)| {
                 if let Some(name) = key_value_pair(segment) {
                     if let Some(lambda) = opt_lambda_state {
-                        state = add_key_value(&name, &mut self.state_machine, lambda);
+                        state = add_key_value(&mut self.state_machine, name, lambda);
                         self.state_machine.add_next_state(state, lambda);
                         opt_final_states.push(state);
                     } else {
                         opt_final_states.push(state);
                         state = add_space(&mut self.state_machine, state, i);
                         opt_lambda_state = Some(state);
-                        state = add_key_value(&name, &mut self.state_machine, state);
+                        state = add_key_value(&mut self.state_machine, name, state);
                         self.state_machine
                             .add_next_state(state, opt_lambda_state.unwrap());
                         opt_final_states.push(state);
@@ -66,21 +66,21 @@ impl Commands {
 
                     if segment.starts_with("```\n") && segment.ends_with("```") {
                         let name = &segment[4..segment.len() - 3];
-                        state = add_code_segment_multi_line(name, &mut self.state_machine, state);
+                        state = add_code_segment_multi_line(&mut self.state_machine, name, state);
                     } else if segment.starts_with("```") && segment.ends_with("```") {
                         let name = &segment[3..segment.len() - 3];
                         state =
-                            add_code_segment_single_line(name, &mut self.state_machine, state, 3);
+                            add_code_segment_single_line(&mut self.state_machine, name, state, 3);
                     } else if segment.starts_with("`") && segment.ends_with("`") {
                         let name = &segment[1..segment.len() - 1];
                         state =
-                            add_code_segment_single_line(name, &mut self.state_machine, state, 1);
+                            add_code_segment_single_line(&mut self.state_machine, name, state, 1);
                     } else if segment.starts_with("{") && segment.ends_with("}") {
                         let name = &segment[1..segment.len() - 1];
-                        state = add_dynamic_segment(name, &mut self.state_machine, state);
+                        state = add_dynamic_segment(&mut self.state_machine, name, state);
                     } else if segment.ends_with("...") {
                         let name = &segment[..segment.len() - 3];
-                        state = add_remaining_segment(name, &mut self.state_machine, state);
+                        state = add_remaining_segment(&mut self.state_machine, name, state);
                     } else {
                         segment.chars().for_each(|ch| {
                             state = self.state_machine.add(state, CharacterSet::from_char(ch))
@@ -157,8 +157,8 @@ fn add_space(state_machine: &mut StateMachine, mut state: usize, i: usize) -> us
 }
 
 fn add_dynamic_segment(
-    name: &'static str,
     state_machine: &mut StateMachine,
+    name: &'static str,
     mut state: usize,
 ) -> usize {
     let mut char_set = CharacterSet::any();
@@ -172,8 +172,8 @@ fn add_dynamic_segment(
 }
 
 fn add_remaining_segment(
-    name: &'static str,
     state_machine: &mut StateMachine,
+    name: &'static str,
     mut state: usize,
 ) -> usize {
     let char_set = CharacterSet::any();
@@ -186,8 +186,8 @@ fn add_remaining_segment(
 }
 
 fn add_code_segment_multi_line(
-    name: &'static str,
     state_machine: &mut StateMachine,
+    name: &'static str,
     mut state: usize,
 ) -> usize {
     state = state_machine.add(state, CharacterSet::from_char('`'));
@@ -220,8 +220,8 @@ fn add_code_segment_multi_line(
 }
 
 fn add_code_segment_single_line(
-    name: &'static str,
     state_machine: &mut StateMachine,
+    name: &'static str,
     mut state: usize,
     n_backticks: usize,
 ) -> usize {
@@ -239,7 +239,7 @@ fn add_code_segment_single_line(
     state
 }
 
-fn add_key_value(name: &'static str, state_machine: &mut StateMachine, mut state: usize) -> usize {
+fn add_key_value(state_machine: &mut StateMachine, name: &'static str, mut state: usize) -> usize {
     name.chars().for_each(|c| {
         state = state_machine.add(state, CharacterSet::from_char(c));
     });


### PR DESCRIPTION
This PR adds support for optional arguments in commands.  

### Example 1
Optional arguments use the following syntax `name={}`.  The following command has 2 optional arguments: `edition` and `build`.  Optional arguments can be used in any order when defined adjacently.   
```rust
cmds.add("?test edition={} build={}", |_| Ok(()));
```
Since `edition` and `build` are both optional, all of the following match this command:
+ `?test`
+ `?test edition=2018 build=nightly`
+ `?test build=nightly edition=2018`
+ `?test build=nightly`
+ `?test edition=2018`

### Example 2
As stated in example 1, optional arguments can be used in any order when defined adjacently.  When defined non-adjacently optional arguments can be used in any order within their local adjacent group.  

```rust
cmds.add("?test verbose={} author={} superSizeForOnlyADollarMore={} ```code``` edition={} build={}", |_| Ok(()));
```
The optional arguments are `verbose`, `author`, `edition`, `build` and `superSizeForOnlyADollarMore`.  `verbose`, `author` and `superSizeForOnlyADollarMore` are adjacent so they can be used in any order such as
+ `?test verbose=yes supeSizeForOnlyADollarMore=no author=technetos .....`
+ `?test author=technetos verbose=yes superSizeForOnlyADollarMore=no .....`
+ `?test verbose=no .....`
+ ...you get the idea

Likewise, `edition` and `build` are adjecent so they can be used in any order in their group
+ `..... edition=2018 build=nightly`
+ `..... build=nightly edition=2018`
+ `..... build=nightly`
+ ...and so on

In example 2 I used `.....` to denote that there is more command remaining and the section before it or after it was the content in question, it was easier than dealing with formatting ```s

#53 