### PR TITLE
add protected commands and protected help menu items

### DIFF
--- a/src/ban.rs
+++ b/src/ban.rs
@@ -79,43 +79,41 @@ pub(crate) fn start_unban_thread(cx: Context) {
 ///
 /// Requires the ban members permission
 pub(crate) fn temp_ban(args: Args) -> Result<()> {
-    if api::is_mod(&args)? {
-        let user_id = parse_username(
-            &args
-                .params
-                .get("user")
-                .ok_or("unable to retrieve user param")?,
-        )
-        .ok_or("unable to retrieve user id")?;
-
-        use std::str::FromStr;
-
-        let hours = u64::from_str(
-            args.params
-                .get("hours")
-                .ok_or("unable to retrieve hours param")?,
-        )?;
-
-        let reason = args
+    let user_id = parse_username(
+        &args
             .params
-            .get("reason")
-            .ok_or("unable to retrieve reason param")?;
+            .get("user")
+            .ok_or("unable to retrieve user param")?,
+    )
+    .ok_or("unable to retrieve user id")?;
 
-        if let Some(guild) = args.msg.guild(&args.cx) {
-            info!("Banning user from guild");
-            let user = UserId::from(user_id);
+    use std::str::FromStr;
 
-            user.create_dm_channel(args.cx)?
-                .say(args.cx, ban_message(reason, hours))?;
+    let hours = u64::from_str(
+        args.params
+            .get("hours")
+            .ok_or("unable to retrieve hours param")?,
+    )?;
 
-            guild.read().ban(args.cx, &user, &"all")?;
+    let reason = args
+        .params
+        .get("reason")
+        .ok_or("unable to retrieve reason param")?;
 
-            save_ban(
-                format!("{}", user_id),
-                format!("{}", guild.read().id),
-                hours,
-            )?;
-        }
+    if let Some(guild) = args.msg.guild(&args.cx) {
+        info!("Banning user from guild");
+        let user = UserId::from(user_id);
+
+        user.create_dm_channel(args.cx)?
+            .say(args.cx, ban_message(reason, hours))?;
+
+        guild.read().ban(args.cx, &user, &"all")?;
+
+        save_ban(
+            format!("{}", user_id),
+            format!("{}", guild.read().id),
+            hours,
+        )?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ use serde::Deserialize;
 use serenity::{model::prelude::*, prelude::*};
 use std::collections::HashMap;
 
-
 #[derive(Deserialize)]
 struct Config {
     tags: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn app() -> Result<()> {
 
     let menu = cmds.menu();
     cmds.add("?help", move |args: Args| {
-        let output = main_menu(&args, menu.as_ref().unwrap())?;
+        let output = main_menu(&args, menu.as_ref().unwrap());
         api::send_reply(&args, &format!("```{}```", &output))?;
         Ok(())
     });
@@ -163,7 +163,7 @@ fn app() -> Result<()> {
     Ok(())
 }
 
-fn main_menu(args: &Args, commands: &HashMap<&str, (&str, GuardFn)>) -> Result<String> {
+fn main_menu(args: &Args, commands: &HashMap<&str, (&str, GuardFn)>) -> String {
     let mut menu = format!("Commands:\n");
 
     menu = commands
@@ -177,7 +177,7 @@ fn main_menu(args: &Args, commands: &HashMap<&str, (&str, GuardFn)>) -> Result<S
 
     menu += &format!("\t{help:<12}This menu\n", help = "?help");
     menu += "\nType ?help command for more info on a command.";
-    Ok(menu)
+    menu
 }
 
 fn main() {

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -1,4 +1,3 @@
-use crate::commands::CmdPtr;
 use std::{collections::HashMap, u64};
 
 /// # CharacterSet
@@ -85,21 +84,21 @@ impl CharacterSet {
     }
 }
 
-pub(crate) struct State {
+pub(crate) struct State<T> {
     index: usize,
     expected: CharacterSet,
     next_states: Vec<usize>,
     is_final_state: bool,
-    handler: Option<CmdPtr>,
+    handler: Option<T>,
 }
 
-impl PartialEq for State {
-    fn eq(&self, other: &State) -> bool {
+impl<T> PartialEq for State<T> {
+    fn eq(&self, other: &State<T>) -> bool {
         self.index == other.index
     }
 }
 
-impl State {
+impl<T> State<T> {
     pub(crate) fn new(index: usize, expected: CharacterSet) -> Self {
         Self {
             index,
@@ -155,18 +154,18 @@ impl Traversal {
     }
 }
 
-pub(crate) struct Match<'m> {
-    pub handler: &'m CmdPtr,
+pub(crate) struct Match<'m, T> {
+    pub handler: &'m T,
     pub params: HashMap<&'static str, &'m str>,
 }
 
-pub(crate) struct StateMachine {
-    states: Vec<State>,
+pub(crate) struct StateMachine<T> {
+    states: Vec<State<T>>,
     start_parse: Vec<Option<&'static str>>,
     end_parse: Vec<bool>,
 }
 
-impl StateMachine {
+impl<T> StateMachine<T> {
     pub(crate) fn new() -> Self {
         Self {
             states: vec![State::new(0, CharacterSet::new())],
@@ -214,7 +213,7 @@ impl StateMachine {
     }
 
     /// Set the handler function for a state.  
-    pub(crate) fn set_handler(&mut self, index: usize, handler: CmdPtr) {
+    pub(crate) fn set_handler(&mut self, index: usize, handler: T) {
         let state = &mut self.states[index];
         state.handler = Some(handler);
     }
@@ -232,7 +231,7 @@ impl StateMachine {
     }
 
     /// Run the input through the state machine, optionally returning a handler and params.  
-    pub(crate) fn process<'m>(&'m self, input: &'m str) -> Option<Match<'m>> {
+    pub(crate) fn process<'m>(&'m self, input: &'m str) -> Option<Match<'m, T>> {
         let mut traversals = vec![Traversal::new()];
 
         for (i, ch) in input.chars().enumerate() {

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -1,16 +1,15 @@
 use crate::{
     api,
-    commands::Args,
+    commands::{Args, Result},
     db::DB,
     schema::{messages, roles, users},
     text::WELCOME_BILLBOARD,
-    Result,
 };
 use diesel::prelude::*;
 use serenity::{model::prelude::*, prelude::*};
 
 /// Write the welcome message to the welcome channel.  
-pub(crate) fn post_message(args: Args) -> Result {
+pub(crate) fn post_message(args: Args) -> Result<()> {
     use std::str::FromStr;
 
     if api::is_mod(&args)? {
@@ -64,7 +63,7 @@ pub(crate) fn post_message(args: Args) -> Result {
     Ok(())
 }
 
-pub(crate) fn assign_talk_role(cx: &Context, ev: &ReactionAddEvent) -> Result {
+pub(crate) fn assign_talk_role(cx: &Context, ev: &ReactionAddEvent) -> Result<()> {
     let reaction = &ev.reaction;
 
     let channel = reaction.channel(cx)?;
@@ -133,7 +132,7 @@ pub(crate) fn assign_talk_role(cx: &Context, ev: &ReactionAddEvent) -> Result {
     Ok(())
 }
 
-pub(crate) fn help(args: Args) -> Result {
+pub(crate) fn help(args: Args) -> Result<()> {
     let help_string = format!(
         "
 Post the welcome message to `channel`


### PR DESCRIPTION
This PR adds role based protection to the commands in the form of `add_protected` and `help_protected` methods.  Both of those methods take a single command guard. 

A command guard is a function pointer in the form of `(&Args) -> Result<bool>`

These guards are used to prevent commands from being executed without authorization and to improve the generation of the help menu.  

Specifically, the help menu will only display the commands available to you as a user with a set of roles.  