### PR TITLE
a few ?play fixes and improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn app() -> Result<()> {
     if config.eval {
         // rust playground
         cmds.add(
-            "?play mode={} edition={} channel={} ```\ncode```",
+            "?play mode={} edition={} channel={} warn={} ```\ncode```",
             playground::run,
         );
         cmds.add("?play code...", playground::err);
@@ -124,15 +124,15 @@ fn app() -> Result<()> {
         );
 
         cmds.add(
-            "?eval mode={} edition={} channel={} ```\ncode```",
+            "?eval mode={} edition={} channel={} warn={} ```\ncode```",
             playground::eval,
         );
         cmds.add(
-            "?eval mode={} edition={} channel={} ```code```",
+            "?eval mode={} edition={} channel={} warn={} ```code```",
             playground::eval,
         );
         cmds.add(
-            "?eval mode={} edition={} channel={} `code`",
+            "?eval mode={} edition={} channel={} warn={} `code`",
             playground::eval,
         );
         cmds.add("?eval code...", playground::eval_err);


### PR DESCRIPTION
* fixed issue causing the first line of output to sometimes fail to display
* added output line limit (45 lines is just slightly under the amount of code lines that can fit on screen in my discord client)
* added warn=true optional parameter, similar to `?playwarn` in the old bot, it outputs both stdout and stderr.