### PR TITLE
Report hours parsing error to user as well as to the error log

### DIFF
--- a/src/ban.rs
+++ b/src/ban.rs
@@ -102,11 +102,17 @@ pub(crate) fn temp_ban(args: Args) -> Result<()> {
 
     use std::str::FromStr;
 
-    let hours = u64::from_str(
+    let hours = match u64::from_str(
         args.params
             .get("hours")
             .ok_or("unable to retrieve hours param")?,
-    )?;
+    ) {
+        Ok(hours) => hours,
+        Err(e) => {
+            api::send_reply(&args, &format!("{}", e))?;
+            return Err(Box::new(e));
+        }
+    };
 
     let reason = args
         .params


### PR DESCRIPTION
Updates the ban command to inform a user when they have used a non-numeric value for `hours`.  