### PR TITLE
Refactor some code to be more maintainable

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,14 +1,9 @@
-use crate::{
-    commands::{Args, Result},
-    db::DB,
-    schema::roles,
-    CommandHistory,
-};
+use crate::{command_history::CommandHistory, commands::Args, db::DB, schema::roles, Error};
 use diesel::prelude::*;
 use serenity::{model::prelude::*, utils::parse_username};
 
 /// Send a reply to the channel the message was received on.  
-pub(crate) fn send_reply(args: &Args, message: &str) -> Result<()> {
+pub(crate) fn send_reply(args: &Args, message: &str) -> Result<(), Error> {
     if let Some(response_id) = response_exists(args) {
         info!("editing message: {:?}", response_id);
         args.msg
@@ -33,7 +28,7 @@ fn response_exists(args: &Args) -> Option<MessageId> {
 }
 
 /// Determine if a member sending a message has the `Role`.  
-pub(crate) fn has_role(args: &Args, role: &RoleId) -> Result<bool> {
+pub(crate) fn has_role(args: &Args, role: &RoleId) -> Result<bool, Error> {
     Ok(args
         .msg
         .member
@@ -43,7 +38,7 @@ pub(crate) fn has_role(args: &Args, role: &RoleId) -> Result<bool> {
         .contains(role))
 }
 
-fn check_permission(args: &Args, role: Option<String>) -> Result<bool> {
+fn check_permission(args: &Args, role: Option<String>) -> Result<bool, Error> {
     use std::str::FromStr;
     if let Some(role_id) = role {
         Ok(has_role(args, &RoleId::from(u64::from_str(&role_id)?))?)
@@ -53,7 +48,7 @@ fn check_permission(args: &Args, role: Option<String>) -> Result<bool> {
 }
 
 /// Return whether or not the user is a mod.  
-pub(crate) fn is_mod(args: &Args) -> Result<bool> {
+pub(crate) fn is_mod(args: &Args) -> Result<bool, Error> {
     let role = roles::table
         .filter(roles::name.eq("mod"))
         .first::<(i32, String, String)>(&DB.get()?)
@@ -62,7 +57,7 @@ pub(crate) fn is_mod(args: &Args) -> Result<bool> {
     check_permission(args, role.map(|(_, role_id, _)| role_id))
 }
 
-pub(crate) fn is_wg_and_teams(args: &Args) -> Result<bool> {
+pub(crate) fn is_wg_and_teams(args: &Args) -> Result<bool, Error> {
     let role = roles::table
         .filter(roles::name.eq("wg_and_teams"))
         .first::<(i32, String, String)>(&DB.get()?)
@@ -74,7 +69,7 @@ pub(crate) fn is_wg_and_teams(args: &Args) -> Result<bool> {
 /// Set slow mode for a channel.  
 ///
 /// A `seconds` value of 0 will disable slowmode
-pub(crate) fn slow_mode(args: Args) -> Result<()> {
+pub(crate) fn slow_mode(args: Args) -> Result<(), Error> {
     use std::str::FromStr;
 
     if is_mod(&args)? {
@@ -95,7 +90,7 @@ pub(crate) fn slow_mode(args: Args) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn slow_mode_help(args: Args) -> Result<()> {
+pub(crate) fn slow_mode_help(args: Args) -> Result<(), Error> {
     let help_string = "
 Set slowmode on a channel
 ```
@@ -119,7 +114,7 @@ will disable slowmode on the `#bot-usage` channel.";
 /// Kick a user from the guild.  
 ///
 /// Requires the kick members permission
-pub(crate) fn kick(args: Args) -> Result<()> {
+pub(crate) fn kick(args: Args) -> Result<(), Error> {
     if is_mod(&args)? {
         let user_id = parse_username(
             &args
@@ -137,7 +132,7 @@ pub(crate) fn kick(args: Args) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn kick_help(args: Args) -> Result<()> {
+pub(crate) fn kick_help(args: Args) -> Result<(), Error> {
     let help_string = "
 Kick a user from the guild
 ```

--- a/src/command_history.rs
+++ b/src/command_history.rs
@@ -1,0 +1,51 @@
+use crate::{Commands, Error, SendSyncError, HOUR};
+use indexmap::IndexMap;
+use serenity::{model::prelude::*, prelude::*, utils::CustomMessage};
+use std::time::Duration;
+
+const MESSAGE_AGE_MAX: Duration = Duration::from_secs(HOUR);
+
+pub(crate) struct CommandHistory;
+
+impl TypeMapKey for CommandHistory {
+    type Value = IndexMap<MessageId, MessageId>;
+}
+
+pub(crate) fn replay_message(
+    cx: Context,
+    ev: MessageUpdateEvent,
+    cmds: &Commands,
+) -> Result<(), Error> {
+    let age = ev.timestamp.and_then(|create| {
+        ev.edited_timestamp
+            .and_then(|edit| edit.signed_duration_since(create).to_std().ok())
+    });
+
+    if age.is_some() && age.unwrap() < MESSAGE_AGE_MAX {
+        let mut msg = CustomMessage::new();
+        msg.id(ev.id)
+            .channel_id(ev.channel_id)
+            .content(ev.content.unwrap_or_else(|| String::new()));
+
+        let msg = msg.build();
+        info!(
+            "sending edited message - {:?} {:?}",
+            msg.content, msg.author
+        );
+        cmds.execute(cx, &msg);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn clear_command_history(cx: &Context) -> Result<(), SendSyncError> {
+    let mut data = cx.data.write();
+    let history = data.get_mut::<CommandHistory>().unwrap();
+
+    // always keep the last command in history
+    if history.len() > 0 {
+        info!("Clearing command history");
+        history.drain(..history.len() - 1);
+    }
+    Ok(())
+}

--- a/src/command_history.rs
+++ b/src/command_history.rs
@@ -1,4 +1,7 @@
-use crate::{Commands, Error, SendSyncError, HOUR};
+use crate::{
+    commands::{Commands, PREFIX},
+    Error, SendSyncError, HOUR,
+};
 use indexmap::IndexMap;
 use serenity::{model::prelude::*, prelude::*, utils::CustomMessage};
 use std::time::Duration;
@@ -28,11 +31,14 @@ pub(crate) fn replay_message(
             .content(ev.content.unwrap_or_else(|| String::new()));
 
         let msg = msg.build();
-        info!(
-            "sending edited message - {:?} {:?}",
-            msg.content, msg.author
-        );
-        cmds.execute(cx, &msg);
+
+        if msg.content.starts_with(PREFIX) {
+            info!(
+                "sending edited message - {:?} {:?}",
+                msg.content, msg.author
+            );
+            cmds.execute(cx, &msg);
+        }
     }
 
     Ok(())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,7 +8,7 @@ use reqwest::blocking::Client as HttpClient;
 use serenity::{model::channel::Message, prelude::Context};
 use std::{collections::HashMap, sync::Arc};
 
-const PREFIX: &'static str = "?";
+pub(crate) const PREFIX: &'static str = "?";
 pub(crate) type GuardFn = fn(&Args) -> Result<bool, Error>;
 
 struct Command {

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -1,7 +1,4 @@
-use crate::{
-    api,
-    commands::{Args, Result},
-};
+use crate::{api, commands::Args, Error};
 
 use reqwest::header;
 use serde::Deserialize;
@@ -25,7 +22,7 @@ struct Crate {
     documentation: Option<String>,
 }
 
-fn get_crate(args: &Args) -> Result<Option<Crate>> {
+fn get_crate(args: &Args) -> Result<Option<Crate>, Error> {
     let query = args
         .params
         .get("query")
@@ -44,7 +41,7 @@ fn get_crate(args: &Args) -> Result<Option<Crate>> {
     Ok(crate_list.crates.into_iter().nth(0))
 }
 
-pub fn search(args: Args) -> Result<()> {
+pub fn search(args: Args) -> Result<(), Error> {
     if let Some(krate) = get_crate(&args)? {
         args.msg.channel_id.send_message(&args.cx, |m| {
             m.embed(|e| {
@@ -79,7 +76,7 @@ fn rustc_crate(crate_name: &str) -> Option<&str> {
     }
 }
 
-pub fn doc_search(args: Args) -> Result<()> {
+pub fn doc_search(args: Args) -> Result<(), Error> {
     let query = args
         .params
         .get("query")
@@ -114,7 +111,7 @@ pub fn doc_search(args: Args) -> Result<()> {
 }
 
 /// Print the help message
-pub fn help(args: Args) -> Result<()> {
+pub fn help(args: Args) -> Result<(), Error> {
     let help_string = "search for a crate on crates.io
 ```
 ?crate query...
@@ -124,7 +121,7 @@ pub fn help(args: Args) -> Result<()> {
 }
 
 /// Print the help message
-pub fn doc_help(args: Args) -> Result<()> {
+pub fn doc_help(args: Args) -> Result<(), Error> {
     let help_string = "retrieve documentation for a given crate
 ```
 ?docs crate_name...

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-use crate::commands::Result;
+use crate::Error;
 use diesel::prelude::*;
 use diesel::r2d2;
 use lazy_static::lazy_static;
@@ -12,7 +12,7 @@ lazy_static! {
     .expect("Unable to connect to database");
 }
 
-pub(crate) fn run_migrations() -> Result<()> {
+pub(crate) fn run_migrations() -> Result<(), Error> {
     let conn = PgConnection::establish(&std::env::var("DATABASE_URL")?)?;
 
     diesel_migrations::embed_migrations!();

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,0 +1,23 @@
+use crate::{ban::unban_users, command_history::clear_command_history, SendSyncError, HOUR};
+use serenity::client::Context;
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    thread::sleep,
+    time::Duration,
+};
+
+static JOBS_THREAD_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn start_jobs(cx: Context) {
+    if !JOBS_THREAD_INITIALIZED.load(Ordering::SeqCst) {
+        JOBS_THREAD_INITIALIZED.store(true, Ordering::SeqCst);
+        std::thread::spawn(move || -> Result<(), SendSyncError> {
+            loop {
+                unban_users(&cx)?;
+                clear_command_history(&cx)?;
+
+                sleep(Duration::new(HOUR, 0));
+            }
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,11 @@ extern crate log;
 
 mod api;
 mod ban;
+mod command_history;
 mod commands;
 mod crates;
 mod db;
+mod jobs;
 mod playground;
 mod schema;
 mod state_machine;
@@ -20,15 +22,18 @@ mod text;
 mod welcome;
 
 use crate::db::DB;
-use commands::{Args, Commands, GuardFn, Result};
+use commands::{Args, Commands, GuardFn};
 use diesel::prelude::*;
 use envy;
 use indexmap::IndexMap;
 use serde::Deserialize;
-use serenity::{model::prelude::*, prelude::*, utils::CustomMessage};
-use std::time::Duration;
+use serenity::{model::prelude::*, prelude::*};
 
-const MESSAGE_AGE_MAX: Duration = Duration::from_secs(3600);
+pub(crate) type Error = Box<dyn std::error::Error>;
+pub(crate) type SendSyncError = Box<dyn std::error::Error + Send + Sync>;
+
+pub(crate) const HOUR: u64 = 3600;
+
 #[derive(Deserialize)]
 struct Config {
     tags: bool,
@@ -40,13 +45,13 @@ struct Config {
     wg_and_teams_id: Option<String>,
 }
 
-fn init_data(config: &Config) -> Result<()> {
+fn init_data(config: &Config) -> Result<(), Error> {
     use crate::schema::roles;
     info!("Loading data into database");
 
     let conn = DB.get()?;
 
-    let upsert_role = |name: &str, role_id: &str| -> Result<()> {
+    let upsert_role = |name: &str, role_id: &str| -> Result<(), Error> {
         diesel::insert_into(roles::table)
             .values((roles::role.eq(role_id), roles::name.eq(name)))
             .on_conflict(roles::name)
@@ -68,7 +73,7 @@ fn init_data(config: &Config) -> Result<()> {
                 let wg_and_teams_role = config
                     .wg_and_teams_id
                     .as_ref()
-                    .ok_or_else(|| "missing value for field wg_and_teams_id.\n\nIf you enabled tags or crates then you need the WG_AND_TEAMS_ID env var.")?;
+                    .ok_or_else(|| text::WG_AND_TEAMS_MISSING_ENV_VAR)?;
                 upsert_role("wg_and_teams", &wg_and_teams_role)?;
             }
 
@@ -78,7 +83,7 @@ fn init_data(config: &Config) -> Result<()> {
     Ok(())
 }
 
-fn app() -> Result<()> {
+fn app() -> Result<(), Error> {
     let config = envy::from_env::<Config>()?;
 
     info!("starting...");
@@ -223,11 +228,6 @@ fn main() {
     }
 }
 
-struct CommandHistory {}
-impl TypeMapKey for CommandHistory {
-    type Value = IndexMap<MessageId, MessageId>;
-}
-
 struct Events {
     cmds: Commands,
 }
@@ -235,12 +235,12 @@ struct Events {
 impl EventHandler for Events {
     fn ready(&self, cx: Context, ready: Ready) {
         info!("{} connected to discord", ready.user.name);
+        {
+            let mut data = cx.data.write();
+            data.insert::<command_history::CommandHistory>(IndexMap::new());
+        }
 
-        let mut data = cx.data.write();
-        data.insert::<CommandHistory>(IndexMap::new());
-        drop(data);
-
-        ban::start_cleanup_thread(cx);
+        jobs::start_jobs(cx);
     }
 
     fn message(&self, cx: Context, message: Message) {
@@ -254,29 +254,14 @@ impl EventHandler for Events {
         _: Option<Message>,
         ev: MessageUpdateEvent,
     ) {
-        let age = ev.timestamp.and_then(|create| {
-            ev.edited_timestamp
-                .and_then(|edit| edit.signed_duration_since(create).to_std().ok())
-        });
-
-        if age.is_some() && age.unwrap() < MESSAGE_AGE_MAX {
-            let mut msg = CustomMessage::new();
-            msg.id(ev.id)
-                .channel_id(ev.channel_id)
-                .content(ev.content.unwrap_or_else(|| String::new()));
-
-            let msg = msg.build();
-            info!(
-                "sending edited message - {:?} {:?}",
-                msg.content, msg.author
-            );
-            self.cmds.execute(cx, &msg);
+        if let Err(e) = command_history::replay_message(cx, ev, &self.cmds) {
+            error!("{}", e);
         }
     }
 
     fn message_delete(&self, cx: Context, channel_id: ChannelId, message_id: MessageId) {
         let mut data = cx.data.write();
-        let history = data.get_mut::<CommandHistory>().unwrap();
+        let history = data.get_mut::<command_history::CommandHistory>().unwrap();
         if let Some(response_id) = history.remove(&message_id) {
             info!("deleting message: {:?}", response_id);
             let _ = channel_id.delete_message(&cx, response_id);

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -1,9 +1,6 @@
 //! run rust code on the rust-lang playground
 
-use crate::{
-    api,
-    commands::{Args, Result},
-};
+use crate::{api, commands::Args, Error};
 
 use reqwest::header;
 use serde::{Deserialize, Serialize};
@@ -70,7 +67,7 @@ enum Channel {
 impl FromStr for Channel {
     type Err = Box<dyn std::error::Error>;
 
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> Result<Self, Error> {
         match s {
             "stable" => Ok(Channel::Stable),
             "beta" => Ok(Channel::Beta),
@@ -91,7 +88,7 @@ enum Edition {
 impl FromStr for Edition {
     type Err = Box<dyn std::error::Error>;
 
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> Result<Self, Error> {
         match s {
             "2015" => Ok(Edition::E2015),
             "2018" => Ok(Edition::E2018),
@@ -118,7 +115,7 @@ enum Mode {
 impl FromStr for Mode {
     type Err = Box<dyn std::error::Error>;
 
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> Result<Self, Error> {
         match s {
             "debug" => Ok(Mode::Debug),
             "release" => Ok(Mode::Release),
@@ -134,7 +131,7 @@ struct PlayResult {
     stderr: String,
 }
 
-fn run_code(args: &Args, code: &str) -> Result<String> {
+fn run_code(args: &Args, code: &str) -> Result<String, Error> {
     let mut errors = String::new();
 
     let warnings = args.params.get("warn").unwrap_or_else(|| &"false");
@@ -196,7 +193,7 @@ fn run_code(args: &Args, code: &str) -> Result<String> {
     )
 }
 
-fn get_playground_link(args: &Args, code: &str, request: &PlaygroundCode) -> Result<String> {
+fn get_playground_link(args: &Args, code: &str, request: &PlaygroundCode) -> Result<String, Error> {
     let mut payload = HashMap::new();
     payload.insert("code", code);
 
@@ -215,7 +212,7 @@ fn get_playground_link(args: &Args, code: &str, request: &PlaygroundCode) -> Res
         .ok_or_else(|| "no gist found".into())
 }
 
-pub fn run(args: Args) -> Result<()> {
+pub fn run(args: Args) -> Result<(), Error> {
     let code = args
         .params
         .get("code")
@@ -226,7 +223,7 @@ pub fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
-pub fn help(args: Args, name: &str) -> Result<()> {
+pub fn help(args: Args, name: &str) -> Result<(), Error> {
     let message = format!(
         "Compile and run rust code. All code is executed on https://play.rust-lang.org.
 ```?{} mode={{}} channel={{}} edition={{}} warn={{}} ``\u{200B}`code``\u{200B}` ```
@@ -243,7 +240,7 @@ Optional arguments:
     Ok(())
 }
 
-pub fn err(args: Args) -> Result<()> {
+pub fn err(args: Args) -> Result<(), Error> {
     let message = "Missing code block. Please use the following markdown:
 \\`\\`\\`rust
     code here
@@ -254,7 +251,7 @@ pub fn err(args: Args) -> Result<()> {
     Ok(())
 }
 
-pub fn eval(args: Args) -> Result<()> {
+pub fn eval(args: Args) -> Result<(), Error> {
     let code = args
         .params
         .get("code")
@@ -274,7 +271,7 @@ pub fn eval(args: Args) -> Result<()> {
     Ok(())
 }
 
-pub fn eval_err(args: Args) -> Result<()> {
+pub fn eval_err(args: Args) -> Result<(), Error> {
     let message = "Missing code block. Please use the following markdown:
     \\`code here\\`
     or

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,14 +1,9 @@
-use crate::{
-    api,
-    commands::{Args, Result},
-    db::DB,
-    schema::tags,
-};
+use crate::{api, commands::Args, db::DB, schema::tags, Error};
 
 use diesel::prelude::*;
 
 /// Remove a key value pair from the tags.  
-pub fn delete(args: Args) -> Result<()> {
+pub fn delete(args: Args) -> Result<(), Error> {
     if api::is_wg_and_teams(&args)? {
         let conn = DB.get()?;
         let key = args
@@ -25,7 +20,7 @@ pub fn delete(args: Args) -> Result<()> {
 }
 
 /// Add a key value pair to the tags.  
-pub fn post(args: Args) -> Result<()> {
+pub fn post(args: Args) -> Result<(), Error> {
     if api::is_wg_and_teams(&args)? {
         let conn = DB.get()?;
 
@@ -57,7 +52,7 @@ pub fn post(args: Args) -> Result<()> {
 }
 
 /// Retrieve a value by key from the tags.  
-pub fn get(args: Args) -> Result<()> {
+pub fn get(args: Args) -> Result<(), Error> {
     let conn = DB.get()?;
 
     let key = args.params.get("key").ok_or("unable to read params")?;
@@ -76,7 +71,7 @@ pub fn get(args: Args) -> Result<()> {
 }
 
 /// Retrieve all tags
-pub fn get_all(args: Args) -> Result<()> {
+pub fn get_all(args: Args) -> Result<(), Error> {
     let conn = DB.get()?;
 
     let results = tags::table.load::<(i32, String, String)>(&conn)?;
@@ -99,7 +94,7 @@ pub fn get_all(args: Args) -> Result<()> {
 }
 
 /// Print the help message
-pub fn help(args: Args) -> Result<()> {
+pub fn help(args: Args) -> Result<(), Error> {
     let help_string = "```
 ?tags create {key} value...     Create a tag.  Limited to WG & Teams.
 ?tags delete {key}              Delete a tag.  Limited to WG & Teams.

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,3 +7,5 @@ If you see someone behaving inappropriately, or otherwise against the Code of Co
 pub(crate) fn ban_message(reason: &str, hours: u64) -> String {
     format!("You have been banned from The Rust Programming Language discord server for {}. The ban will expire in {} hours. If you feel this action was taken unfairly, you can reach the Rust moderation team at discord-mods@rust-lang.org", reason, hours)
 }
+
+pub(crate) const WG_AND_TEAMS_MISSING_ENV_VAR: &'static str = "missing value for field wg_and_teams_id.\n\nIf you enabled tags or crates then you need the WG_AND_TEAMS_ID env var.";

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -1,15 +1,16 @@
 use crate::{
     api,
-    commands::{Args, Result},
+    commands::Args,
     db::DB,
     schema::{messages, roles, users},
     text::WELCOME_BILLBOARD,
+    Error,
 };
 use diesel::prelude::*;
 use serenity::{model::prelude::*, prelude::*};
 
 /// Write the welcome message to the welcome channel.  
-pub(crate) fn post_message(args: Args) -> Result<()> {
+pub(crate) fn post_message(args: Args) -> Result<(), Error> {
     use std::str::FromStr;
 
     if api::is_mod(&args)? {
@@ -63,7 +64,7 @@ pub(crate) fn post_message(args: Args) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn assign_talk_role(cx: &Context, reaction: &Reaction) -> Result<()> {
+pub(crate) fn assign_talk_role(cx: &Context, reaction: &Reaction) -> Result<(), Error> {
     let channel = reaction.channel(cx)?;
     let channel_id = ChannelId::from(&channel);
     let message = reaction.message(cx)?;
@@ -125,7 +126,7 @@ pub(crate) fn assign_talk_role(cx: &Context, reaction: &Reaction) -> Result<()> 
     Ok(())
 }
 
-pub(crate) fn help(args: Args) -> Result<()> {
+pub(crate) fn help(args: Args) -> Result<(), Error> {
     let help_string = format!(
         "
 Post the welcome message to `channel`


### PR DESCRIPTION
This PR moves some things around.  Additionally it switches from a custom `Result` type to 2 custom error types.  

Also:
+ Moves the ban thread that was overloaded with additonal things into its own module where we can just list functions to be run every hour, like a series of jobs
+ Moves command history into its own module
+ A small amount of renaming
