### PR TITLE
Fix for the recently shutdown sks-keyservers.

### DIFF
--- a/postgres-docker/Dockerfile
+++ b/postgres-docker/Dockerfile
@@ -1,8 +1,11 @@
 FROM ubuntu:16.04
 
+# Get the ability to receive gpg keys from hkps://
+RUN apt-get update && apt-get install -y gnupg-curl
+
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
-RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 # Add PostgreSQL's repository. It contains the most recent stable release
 #     of PostgreSQL, ``9.5``.


### PR DESCRIPTION
Switched keyserver to the ubuntu keyserver.