### PR TITLE
fix(playground): eval command failing with trailing single line comments

### DIFF
--- a/src/playground.rs
+++ b/src/playground.rs
@@ -267,7 +267,7 @@ pub fn eval(args: Args) -> Result<(), Error> {
     if code.contains("fn main") {
         api::send_reply(&args, "code passed to ?eval should not contain `fn main`")?;
     } else {
-        let code = format!("fn main(){{ println!(\"{{:?}}\",{{ {} }}); }}", code);
+        let code = format!("fn main(){{ println!(\"{{:?}}\",{{ {} \n}}); }}", code);
 
         let result = run_code(&args, &code)?;
         api::send_reply(&args, &result)?;


### PR DESCRIPTION
If a code passed to `?eval` contains trailing single-line comments, the matching `}` in the code is commented out.

For example:
```
?eval `2 + 2 // returns 4`
```

Will not work as expected.

I've added a single newline(`\n`) in `playground.rs` Where the expression is wrapped in a block to print out
so the `}` is not commented out.