### PR TITLE
use new cargo fmt check option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: rustup update stable && rustup default stable
 
       - name: Check formatting
-        run: cargo fmt -- --check
+        run: cargo fmt --check
 
       - name: Run the test suite
         run: cargo test


### PR DESCRIPTION
As of v1.58, cargo fmt now supports the --check flag directly. Trying to get this utilized in relevant places across the r-l repos both because it's more succinct and so more people will see/become aware they no longer have to invoke the check the old way