### PR TITLE
Only touch `*.rs` under `src`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN cargo build --release
 RUN rm -rf /tmp/source/src
 COPY src /tmp/source/src
 COPY migrations /tmp/source/migrations
-RUN find -name "*.rs" -exec touch {} \; && cargo build --release
+RUN find src -name "*.rs" -exec touch {} \; && cargo build --release
 
 ##################
 #  Output image  #


### PR DESCRIPTION
To avoid having to rebuild dependencies (and thus also all their dependents!) with generated `.rs` files, we have to avoid touching `.rs` files under `target`. Thus we specify `src` explicitly as the path to `find`.